### PR TITLE
add Python + pkg-config as build dependencies for Rust 1.52.1 with GCCcore/10.2.0

### DIFF
--- a/easybuild/easyconfigs/r/Rust/Rust-1.52.1-GCCcore-10.2.0.eb
+++ b/easybuild/easyconfigs/r/Rust/Rust-1.52.1-GCCcore-10.2.0.eb
@@ -16,6 +16,8 @@ checksums = ['3a6f23a26d0e8f87abbfbf32c5cd7daa0c0b71d0986abefc56b9a5fbfbd0bf98']
 builddependencies = [
     ('binutils', '2.35'),
     ('CMake', '3.18.4'),
+    ('Python', '3.8.6'),
+    ('pkg-config', '0.29.2'),
 ]
 
 dependencies = [


### PR DESCRIPTION
@sassy-crick for https://github.com/easybuilders/easybuild-easyconfigs/pull/13998