### PR TITLE
[FEniCS-DOLPHINx] Add KaHIP and add compilation comnfiguration checks

### DIFF
--- a/easybuild/easyconfigs/f/FEniCS-DOLFINx/FEniCS-DOLFINx-0.10.0.post5-foss-2025b.eb
+++ b/easybuild/easyconfigs/f/FEniCS-DOLFINx/FEniCS-DOLFINx-0.10.0.post5-foss-2025b.eb
@@ -23,6 +23,7 @@ builddependencies = [
 
 dependencies = [
     ('Boost', '1.88.0'),
+    ('KaHIP', '3.19'),
     ('ParMETIS', '4.0.3'),
     ('HDF5', '1.14.6'),
     ('PETSc', '3.24.0'),
@@ -39,6 +40,10 @@ srcdir = 'cpp'
 configopts = (
     ' -DDOLFINX_UFCX_PYTHON=OFF '
     ' -DDOLFINX_BASIX_PYTHON=OFF '
+    ' -DDOLFINX_ENABLE_KAHIP=ON '
+    ' -DDOLFINX_ENABLE_PETSC=ON '
+    ' -DDOLFINX_ENABLE_SLEPC=ON '
+    # ' -DDOLFINX_ENABLE_PARMETIS=ON ' # Strict check disabled to enable EESSI build.
 )
 
 sanity_check_paths = {


### PR DESCRIPTION
- ParMETIS is not available in EESSI; add support for KaHIP as alternative back end.
- Add CMake flags to check that the packages of the dependencies where indeed found.